### PR TITLE
Handle complex locks without code in startCheck and additionalChecks

### DIFF
--- a/js/challenge-ui.js
+++ b/js/challenge-ui.js
@@ -1347,6 +1347,55 @@ function chDoStartChecks() {
 function chDoStartChecksFleet(fleetnum,errors) {
 	var mdata = MAPDATA[WORLD].maps[MAPNUM];
 	var first = true;
+	
+	let locksToCheck = null;
+
+	if (mdata.lockInfos) {
+		// Complex locks
+		const lockInfos = mdata.lockInfos;
+
+		if (lockInfos.difficulties.includes(CHDATA.event.maps[MAPNUM].diff)) {
+			// get tag
+			if (lockInfos.isTagAllowed.startNode && Object.values(lockInfos.isTagAllowed.startNode).length) {
+				// get start node
+				let startNode = "Start";
+
+				if (mdata.startCheck) startNode = mdata.startCheck();
+
+				if (mdata.startCheckRule && mdata.startCheckRule.length) {
+					startNode = '';
+					let index = 0;
+					let rules = mdata.startCheckRule;
+
+					while (!startNode) {
+
+						let rule = rules[index];
+
+						if (!rule) {
+							startNode = 'Start'
+						}
+
+						if (rule.ruleCanBeChecked()) startNode = rule.getRouting(CHSHIPCOUNT);
+
+						index++;
+					}
+				}
+
+				if (startNode && lockInfos.isTagAllowed.startNode[startNode]) locksToCheck = lockInfos.isTagAllowed.startNode[startNode];
+
+			} else if (lockInfos.isTagAllowed.fleetType && Object.values(lockInfos.isTagAllowed.fleetType).length) {
+				if (CHDATA.fleets.combined) {
+					locksToCheck = lockInfos.isTagAllowed.fleetType[CHDATA.fleets.combined];
+				} else if (CHDATA.fleets.sf) {
+					locksToCheck = lockInfos.isTagAllowed.fleetType[7];
+				} else {
+					locksToCheck = lockInfos.isTagAllowed.fleetType[0];
+				}
+			}
+		}
+
+	}
+
 	for (var i=0; i<CHDATA.fleets[fleetnum].length; i++) {
 		ship = CHDATA.ships[CHDATA.fleets[fleetnum][i]];
 		if (!ship) continue;
@@ -1360,10 +1409,15 @@ function chDoStartChecksFleet(fleetnum,errors) {
 		}
 		//ship lock
 		if (!CHDATA.config.disablelock) {
-			if (CHDATA.event.maps[MAPNUM].diff > 1 && CHDATA.event.maps[MAPNUM].diff < 4 && mdata.checkLock && ship.lock && mdata.checkLock.indexOf(ship.lock) != -1)
-				errors.push(SHIPDATA[ship.masterId].name + ' is locked to another map.');
-			if (CHDATA.event.maps[MAPNUM].diff == 3 && mdata.checkLockHard && ship.lock && mdata.checkLockHard.indexOf(ship.lock) != -1)
-				errors.push(SHIPDATA[ship.masterId].name + ' is locked to another map.');
+			if (mdata.lockInfos) { 
+				if (locksToCheck && ship.lock && !locksToCheck.includes(ship.lock)) 
+					errors.push(SHIPDATA[ship.masterId].name + ' is locked to another map/part.');
+			} else {
+				if (CHDATA.event.maps[MAPNUM].diff > 1 && CHDATA.event.maps[MAPNUM].diff < 4 && mdata.checkLock && ship.lock && mdata.checkLock.indexOf(ship.lock) != -1)
+					errors.push(SHIPDATA[ship.masterId].name + ' is locked to another map.');
+				if (CHDATA.event.maps[MAPNUM].diff == 3 && mdata.checkLockHard && ship.lock && mdata.checkLockHard.indexOf(ship.lock) != -1)
+					errors.push(SHIPDATA[ship.masterId].name + ' is locked to another map.');
+			}
 		}
 		//empty item slots
 		var noitem1 = 0, noitem2 = 0;
@@ -1424,6 +1478,10 @@ function chStart() {
 	SIMCONSTS.enableModFrenchBB = WORLD >= 51;
 	toggleEchelon(CHDATA.config.mechanics.echelonBuff);
 	toggleDDCIBuff(MECHANICS.subFleetAttack);
+
+	if (MAPDATA[WORLD].maps[MAPNUM].lockInfos) {
+		chApplyLocksBeforeSortie();
+	}
 
 	chLoadMainFleet();
 	if (CHDATA.fleets.combined) chLoadEscortFleet();
@@ -1496,6 +1554,57 @@ function chStart() {
 	chClickedTab('#tabmain');
 	chBlockFleetUI();
 	chPlayerStart();
+}
+
+function chApplyLocksBeforeSortie() {
+	const mdata = MAPDATA[WORLD].maps[MAPNUM];
+	const lockInfos = mdata.lockInfos;
+
+	let lockToApply = null;
+
+	if (lockInfos.difficulties.includes(CHDATA.event.maps[MAPNUM].diff)) {
+		// get tag
+		if (lockInfos.tagGiven.startNode && Object.values(lockInfos.isTagAllowed.startNode).length) {
+			// get start node
+			let startNode = "Start";
+
+			if (mdata.startCheck) startNode = mdata.startCheck();
+
+			if (mdata.startCheckRule && mdata.startCheckRule.length) {
+				startNode = '';
+				let index = 0;
+				let rules = mdata.startCheckRule;
+
+				while (!startNode) {
+
+					let rule = rules[index];
+
+					if (!rule) {
+						startNode = 'Start'
+					}
+
+					if (rule.ruleCanBeChecked()) startNode = rule.getRouting(CHSHIPCOUNT);
+
+					index++;
+				}
+			}
+
+			if (startNode && lockInfos.tagGiven.startNode[startNode]) lockToApply = lockInfos.tagGiven.startNode[startNode];
+
+		} else if (lockInfos.tagGiven.fleetType && Object.values(lockInfos.isTagAllowed.fleetType).length) {
+			if (CHDATA.fleets.combined) {
+				lockToApply = lockInfos.tagGiven.fleetType[CHDATA.fleets.combined];
+			} else if (CHDATA.fleets.sf) {
+				lockToApply = lockInfos.tagGiven.fleetType[7];
+			} else {
+				lockToApply = lockInfos.tagGiven.fleetType[0];
+			}
+		}
+	}
+
+	if (lockToApply) {
+		chGiveLockAllCurrent(lockToApply);
+	}
 }
 
 function chGiveLock(fleetnum,slotnum,lock) {

--- a/js/challenge-ui.js
+++ b/js/challenge-ui.js
@@ -1354,7 +1354,9 @@ function chDoStartChecksFleet(fleetnum,errors) {
 		// Complex locks
 		const lockInfos = mdata.lockInfos;
 
-		if (lockInfos.difficulties.includes(CHDATA.event.maps[MAPNUM].diff)) {
+		const difficulties = lockInfos.difficulties ? lockInfos.difficulties : [2,3];
+
+		if (difficulties) {
 			// get tag
 			if (lockInfos.isTagAllowed.startNode && Object.values(lockInfos.isTagAllowed.startNode).length) {
 				// get start node
@@ -1561,8 +1563,10 @@ function chApplyLocksBeforeSortie() {
 	const lockInfos = mdata.lockInfos;
 
 	let lockToApply = null;
+	
+	const difficulties = lockInfos.difficulties ? lockInfos.difficulties : [2,3];
 
-	if (lockInfos.difficulties.includes(CHDATA.event.maps[MAPNUM].diff)) {
+	if (difficulties) {
 		// get tag
 		if (lockInfos.tagGiven.startNode && Object.values(lockInfos.isTagAllowed.startNode).length) {
 			// get start node

--- a/js/data/event/mapdata52.js
+++ b/js/data/event/mapdata52.js
@@ -1073,7 +1073,7 @@ MAPDATA[52] =
 					{ type: 'battle', node: 'W', rank: 'S', timesRequiredPerDiff: { 4:1, 1:1, 2:1, 3:1 } },
 					{ type: 'battle', node: 'X', rank: 'S', timesRequiredPerDiff: { 4:1, 1:1, 2:1, 3:1 } },
 				], { lastDanceOnly: true }),
-				additionalChecks: function(ships,errors) {
+				/*additionalChecks: function(ships,errors) {
 					if (getDiff() == 1 || getDiff() == 4 || CHDATA.config.disablelock) return;
 					let lock = CHDATA.fleets.combined ? '52_4' : '52_3';
 					
@@ -1090,6 +1090,27 @@ MAPDATA[52] =
 						if (lock == '52_3') errors.push('Only GREY locks allowed.');
 						else errors.push('Only BLUE locks allowed.');
 					}
+				},*/
+				lockInfos: {
+					isTagAllowed: {
+						fleetType: {
+							0: ['52_3'],
+							1: ['52_4'],
+							2: ['52_4'],
+							3: ['52_4'],
+							7: ['52_3'],
+						}
+					},
+
+					tagGiven: {
+						fleetType: {
+							0: '52_3',
+							1: '52_4',
+							2: '52_4',
+							3: '52_4',
+							7: '52_3',
+						}
+					},
 				},
 				bonuses: {
 					base: [
@@ -1122,8 +1143,8 @@ MAPDATA[52] =
 					],
 				},
 				startCheck: function(ships) {
-					let lock = CHDATA.fleets.combined ? '52_4' : '52_3';
-					chGiveLockAllCurrent(lock);
+					/*let lock = CHDATA.fleets.combined ? '52_4' : '52_3';
+					chGiveLockAllCurrent(lock);*/
 					
 					chApplyBonus(this.bonuses.base);
 					


### PR DESCRIPTION
This is an attempt to handle complex locks on maps without relying on coding it in startCheck and additionalChecks.
Goal is to have the same format with event editor (to import existing event in it).

Property in map : lockInfos

Properties : 
- difficulties (Array of number for every difficulties to apply locks, [2,3] is used by default).
- isTagAllowed (Object to define the conditions to allow a tag to sortie)
  - startNode (Object)
    - Key is the node where the fleet will start
    - Value is an array of tag allowed to sortie from this start point
    - Example : `Start1: ['52_1']`                    
  - fleetType(Object)
    - Key is the fleet type
    - Value is an array of tag allowed to sortie for the fleet type
    - Example : `0: ['52_1']`  
- tagGiven (Object to define which tag is given to the fleet)
  - startNode (Object)
    - Key is the node where the fleet will start
    - Value is the tag given to fleet when they start from this start point
    - Example : `Start1: '52_1'`                    
  - fleetType(Object)
    - Key is the fleet type
    - Value is the tag given to this fleet type
    - Example : `0: '52_1'` 
